### PR TITLE
Add Elasticsearch indexes variable ...

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -14,6 +14,7 @@ require "base64"
 #       if [type] == "end" {
 #          elasticsearch {
 #             hosts => ["es-server"]
+#             indexes => ["logstash-*","otheridx-*"]
 #             query => "type:start AND operation:%{[opid]}"
 #             fields => ["@timestamp", "started"]
 #          }
@@ -33,6 +34,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array
+
+  # List of indexes to perform the search query against.
+  config :indexes, :validate => :array, :default => [""]
 
   # Elasticsearch query string
   config :query, :validate => :string
@@ -88,7 +92,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     begin
       query_str = event.sprintf(@query)
 
-      results = @client.search q: query_str, sort: @sort, size: 1
+      results = @client.search index: @indexes, q: query_str, sort: @sort, size: 1
 
       @fields.each do |old, new|
         event[new] = results['hits']['hits'][0]['_source'][old]


### PR DESCRIPTION
...  to avoid querying indexes which do not have the expected document fields.

###### Problem description
When queries are run against the Elasticsearch cluster, no index option is provided.  In this case, the underlying library defaults to "_all".  This is problematic when the ES cluster has indexes which don't contain documents with the field @timestamp.  An Exception is raised by Elasticsearch like the example below: (query masked for privacy reasons)
> Caused by: org.elasticsearch.search.SearchParseException: [kibana-int][0]: query[XXXXXXXX],from[-1],size[1]: Parse Failure [No mapping found for [@timestamp] in order to sort on]

###### Fix
By explicitly providing the list of indexes to run the query against, the above error is avoid.  The indexes variable is optional for the logstash configuration.  If the variable is not set in the configuration, an empty string is supplied by the plugin and the underlying library will use the original behaviour of querying "_all".