### PR TITLE
Ignore unavailable indexes

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -93,7 +93,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     begin
       query_str = event.sprintf(@query)
 
-      results = @client.search index: @indexes, q: query_str, sort: @sort, size: 1
+      results = @client.search index: @indexes, q: query_str, sort: @sort, size: 1, ignore_unavailable: true
 
       @fields.each do |old, new|
         event[new] = results['hits']['hits'][0]['_source'][old]

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -15,6 +15,7 @@ require "base64"
 #       if [type] == "end" {
 #          elasticsearch {
 #             hosts => ["es-server"]
+#             indexes => ["logstash-*","otheridx-*"]
 #             query => "type:start AND operation:%{[opid]}"
 #             fields => ["@timestamp", "started"]
 #          }
@@ -34,6 +35,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array
+
+  # List of indexes to perform the search query against.
+  config :indexes, :validate => :array, :default => [""]
 
   # Elasticsearch query string
   config :query, :validate => :string
@@ -89,7 +93,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     begin
       query_str = event.sprintf(@query)
 
-      results = @client.search q: query_str, sort: @sort, size: 1
+      results = @client.search index: @indexes, q: query_str, sort: @sort, size: 1
 
       @fields.each do |old, new|
         event[new] = results['hits']['hits'][0]['_source'][old]


### PR DESCRIPTION
When querying elasticsearch, ignore unavailable indexes, rather than
raising an error.