### PR TITLE
Corrected 'fields' configuration to be an array 

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -40,8 +40,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Comma-delimited list of `<field>:<direction>` pairs that define the sort order
   config :sort, :validate => :string, :default => "@timestamp:desc"
 
-  # Hash of fields to copy from old event (found via elasticsearch) into new event
-  config :fields, :validate => :hash, :default => {}
+  # Array of fields to copy from old event (found via elasticsearch) into new event
+  config :fields, :validate => :array, :default => {}
 
   # Basic Auth - username
   config :user, :validate => :string


### PR DESCRIPTION
is documented and implemented as array, but defined as a hash which makes for confusing configuration:

Currently if you want to write this:
```
        fields => [ "foo", "bar", "aaa", "bbb" ]
```
But have to write this:

```
        fields => { 
            "foo" => "bar"
            "aaa" => "bbb"
        }
```