### PR TITLE
Update elasticsearch.rb

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -36,6 +36,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # Elasticsearch query string
   config :query, :validate => :string
+  
+  # Elasticsearch index string
+  config :index, :validate => :string, :default => "_all"
 
   # Comma-delimited list of `<field>:<direction>` pairs that define the sort order
   config :sort, :validate => :string, :default => "@timestamp:desc"
@@ -88,7 +91,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     begin
       query_str = event.sprintf(@query)
 
-      results = @client.search q: query_str, sort: @sort, size: 1
+      results = @client.search index: @index, q: query_str, sort: @sort, size: 1
 
       @fields.each do |old, new|
         event[new] = results['hits']['hits'][0]['_source'][old]
@@ -96,7 +99,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
       filter_matched(event)
     rescue => e
-      @logger.warn("Failed to query elasticsearch for previous event",
+      @logger.warn("Failed to query elasticsearch for previous event", :index => @index, 
                    :query => query_str, :event => event, :error => e)
     end
   end # def filter


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

I find in a cluster with many indexes and some are huge, the current filter, without the capability to pin point the specific index, will cause huge load on server because it is trying to search all indexes.

the proposed change is to add an optional index parameter, if not specified, working as previously (default to _all), and if specified, will limit to search for that index (not sure if wildcard works, did not test yet). This will make query on a specific index only to reduce CPU load.