### PR TITLE
adding an option to specify an index, fix of a huge mistake in current documentation, rewriting of hosts handling to have working ssl in Logstash 2.3, adding transport_options to enable advanced underlying Transport Options.

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -15,7 +15,7 @@ require "base64"
 #          elasticsearch {
 #             hosts => ["es-server"]
 #             query => "type:start AND operation:%{[opid]}"
-#             fields => ["@timestamp", "started"]
+#             fields => [["@timestamp", "started"]]
 #          }
 #
 #          date {

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -102,7 +102,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
             host_parts[:user] = @user
           end
           if host_parts[:password].nil?
-            host_parts[:password]  = @password
+            host_parts[:password]  = @password.value
           end
         end
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -33,6 +33,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array
+  
+  # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices
+  config :index, :validate => :string, :default => ""
 
   # Elasticsearch query string
   config :query, :validate => :string
@@ -88,7 +91,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     begin
       query_str = event.sprintf(@query)
 
-      results = @client.search q: query_str, sort: @sort, size: 1
+      results = @client.search index: @index, q: query_str, sort: @sort, size: 1
 
       @fields.each do |old, new|
         event[new] = results['hits']['hits'][0]['_source'][old]
@@ -97,7 +100,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       filter_matched(event)
     rescue => e
       @logger.warn("Failed to query elasticsearch for previous event",
-                   :query => query_str, :event => event, :error => e)
+                   :index => index, :query => query_str, :event => event, :error => e)
     end
   end # def filter
 end # class LogStash::Filters::Elasticsearch

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -34,6 +34,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array
   
+  # Advanced Transport Options usage
+  config :transport_options, :validate => :hash, :default => {}  
+
   # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices
   config :index, :validate => :string, :default => ""
 
@@ -63,7 +66,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   def register
     require "elasticsearch"
 
-    transport_options = {}
+    transport_options = @transport_options
 
     if @user && @password
       token = Base64.strict_encode64("#{@user}:#{@password.value}")
@@ -71,7 +74,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     end
 
     hosts = if @ssl then
-      @hosts.map {|h| { host: h, scheme: 'https' } }
+      @hosts.map {|h| { host: h, port: 9200, scheme: 'https' } }
     else
       @hosts
     end

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
-  s.add_runtime_dependency 'elasticsearch'
+  s.add_runtime_dependency 'elasticsearch',"~> 1.0.15"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
-  s.add_runtime_dependency 'elasticsearch',"~> 1.0.15"
+  s.add_runtime_dependency 'elasticsearch'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Hello, 
This is a pretty simple Pull Request to enable a new setting "index". This setting allows you to specify which Elasticsearch Index you want to query.   

PS. I have signed the Logstash agreement shortly. Is it possible to check it again ? 
