### PR TITLE
Query error and nested field

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -165,9 +165,16 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       results = @client.search(params)
       @fields.each do |old_key, new_key|
         if !results['hits']['hits'].empty?
+          if old_key.include?('][')
+            old_keys = old_key[1...-1].split('][')
+          else
+            old_keys = [old_key]
+          end
           set = []
           results["hits"]["hits"].to_a.each do |doc|
-            set << doc["_source"][old_key]
+            old_val = doc["_source"]
+            old_keys.each { |key| old_val = old_val[key] }
+            set << old_val
           end
           event.set(new_key, set.count > 1 ? set : set.first)
         end

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -147,7 +147,6 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   def filter(event)
     begin
-
       params = {:index => @index }
 
       if @query_dsl
@@ -163,6 +162,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       @logger.debug("Querying elasticsearch for lookup", :params => params)
 
       results = @client.search(params)
+      raise "Elasticsearch query error: #{results["_shards"]["failures"]}" if results["_shards"].include? "failures"
+
       @fields.each do |old_key, new_key|
         if !results['hits']['hits'].empty?
           if old_key.include?('][')

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -122,6 +122,22 @@ describe LogStash::Filters::Elasticsearch do
 
     end
 
+    context "if query is on nested field" do
+      let(:config) do
+        {
+            "hosts" => ["localhost:9200"],
+            "query" => "response: 404",
+            "fields" => [ ["[geoip][ip]", "ip_address"] ]
+        }
+      end
+
+      it "should enhance the current event with new data" do
+        plugin.filter(event)
+        expect(event.get("ip_address")).to eq("66.249.73.185")
+      end
+
+    end
+
   end
 
 end

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -122,6 +122,25 @@ describe LogStash::Filters::Elasticsearch do
 
     end
 
+    context "if query result errored but no exception is thrown" do
+      let(:response) do
+        LogStash::Json.load(File.read(File.join(File.dirname(__FILE__), "fixtures", "request_error.json")))
+      end
+
+      before(:each) do
+        allow(LogStash::Filters::ElasticsearchClient).to receive(:new).and_return(client)
+        allow(client).to receive(:search).and_return(response)
+        plugin.register
+      end
+
+      it "tag the event as something happened, but still deliver it" do
+        expect(plugin.logger).to receive(:warn)
+        plugin.filter(event)
+        expect(event.to_hash["tags"]).to include("_elasticsearch_lookup_failure")
+      end
+    end
+
+
     context "if query is on nested field" do
       let(:config) do
         {

--- a/spec/filters/fixtures/request_error.json
+++ b/spec/filters/fixtures/request_error.json
@@ -1,0 +1,25 @@
+{
+	"took": 16,
+	"timed_out": false,
+	"_shards": {
+		"total": 155,
+		"successful": 100,
+		"failed": 55,
+		"failures": [
+			{
+				"shard": 0,
+				"index": "logstash-2014.08.26",
+				"node": "YI1MT0H-Q469pFgAVTXI2g",
+				"reason": {
+					"type": "search_parse_exception",
+					"reason": "No mapping found for [@timestamp] in order to sort on"
+				}
+			}
+		]
+	},
+	"hits": {
+		"total": 0,
+		"max_score": null,
+		"hits": []
+	}
+}


### PR DESCRIPTION
These commits fix two issues I ran into while trying to use the plugin.  The first issue was that the query response was coming back with no results and a failure message, but because no exception was thrown from the client, there was no logging indicating what the problem was.
The second issue was that I tried to use an old field that was a nested field, which didn't work.  This change allows you to specify a nested field using the normal logstash syntax, so rather than "@timestamp", it would be something like "[top_field][nested_field]".
