### PR TITLE
updated "fields" config example to be a hash

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -16,7 +16,7 @@ require_relative "elasticsearch/client"
 #          elasticsearch {
 #             hosts => ["es-server"]
 #             query => "type:start AND operation:%{[opid]}"
-#             fields => [["@timestamp", "started"]]
+#             fields => { "@timestamp" => "started" }
 #          }
 #
 #          date {


### PR DESCRIPTION
The `fields` config setting is expecting a hash, but the example was using an array.

This resulted in a `#<TypeError: can't convert nil into String>}` error