### PR TITLE
Change loglevel to debug for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Change the queries loglevel from info to debug.
+
 ## 3.1.0
   - Support for full use of query DSL. Added query_template to use full DSL.
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Contributors:
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)
+* Adrian Solom (addrians)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -150,7 +150,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
         params[:sort] =  @sort if @enable_sort
       end
 
-      @logger.info("Querying elasticsearch for lookup", :params => params)
+      @logger.debug("Querying elasticsearch for lookup", :params => params)
 
       results = @client.search(params)
       @fields.each do |old_key, new_key|

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.1.0'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Search elasticsearch for a previous log event and copy some fields from it into the current event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The logging action is very useful for debugging, but it's too noisy for regular use (since the default is `info`, I think we should go with `debug`).

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
