### PR TITLE
Update the plugin documentation with the Logstash 5.0 Event api changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Update the plugin documentation concerning the api change for the Event class
+
 ## 3.1.0
   - Support for full use of query DSL. Added query_template to use full DSL.
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -29,7 +29,7 @@ require "logstash/json"
 #          }
 #
 #          ruby {
-#             code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
+#             code => "event.set('duration_hrs', (event.get('@timestamp') - event.get('started')) / 3600) rescue nil"
 #          }
 #       }
 #
@@ -49,7 +49,7 @@ require "logstash/json"
 #          }
 #
 #          ruby {
-#             code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
+#             code => "event.set('duration_hrs', (event.get('@timestamp') - event.get('started')) / 3600) rescue nil"
 #          }
 #   }
 #

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Search elasticsearch for a previous log event and copy some fields from it into the current event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The doc in this plugin for the ruby filter was using the Hash Style accessor this PR update the documentation with the right `#set/#get` methods.

Fixes: https://github.com/elastic/logstash/issues/6459