### PR TITLE
Add plugin level required to support sending content-type headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Docs: Add requirement to use version 3.1.1 or higher to support sending Content-Type headers.
+  
 ## 3.1.1
   - Upgrade es-ruby client to support correct content-type
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -4,6 +4,16 @@ require "logstash/namespace"
 require_relative "elasticsearch/client"
 require "logstash/json"
 
+# .Compatibility Note
+# [NOTE]
+# ================================================================================
+# Starting with Elasticsearch 5.3, there's an {ref}modules-http.html[HTTP setting]
+# called `http.content_type.required`. If this option is set to `true`, and you
+# are using Logstash 2.4 through 5.2, you need to update the Elasticsearch filter
+# plugin to version 3.1.1 or higher.
+# 
+# ================================================================================
+# 
 # Search Elasticsearch for a previous log event and copy some fields from it
 # into the current event.  Below are two complete examples of how this filter might
 # be used.

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Search elasticsearch for a previous log event and copy some fields from it into the current event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds compatibility note requested in elastic/logstash#6718

@acchen97 Please review. This one is for the elasticsearch filter plugin.
