### PR TITLE
Moved text from example outside of code block

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,11 +58,12 @@ the "end" event.  Finally, using a combination of the "date" filter and the
             code => "event['duration_hrs'] = (event['@timestamp'] - event['started']) / 3600 rescue nil"
          }
       }
-
- The example below reproduces the above example but utilises the query_template.  This query_template represents a full
- Elasticsearch query DSL and supports the standard Logstash field substitution syntax.  The example below issues
- the same query as the first example but uses the template shown.
-
+--------------------------------------------------
+The example below reproduces the above example but utilises the query_template.  This query_template represents a full
+Elasticsearch query DSL and supports the standard Logstash field substitution syntax.  The example below issues
+the same query as the first example but uses the template shown.
+[source,ruby]
+--------------------------------------------------
   if [type] == "end" {
          elasticsearch {
             hosts => ["es-server"]
@@ -91,11 +92,9 @@ the "end" event.  Finally, using a combination of the "date" filter and the
     },
    "_source": ["@timestamp", "started"]
  }
-
+--------------------------------------------------
 As illustrated above, through the use of 'opid', fields from the Logstash events can be referenced within the template.
 The template will be populated per event prior to being used to query Elasticsearch.
-
---------------------------------------------------
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Filter Configuration Options


### PR DESCRIPTION
Text before and after the second example was formatted as code. Moved it out of the code block.