### PR TITLE
Allow access to meta-fields

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -107,7 +107,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-ca_file>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-enable_sort>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-docinfo_fields>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-fields>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
@@ -126,7 +127,7 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-ca_file"]
-===== `ca_file` 
+===== `ca_file`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -134,23 +135,44 @@ filter plugins.
 SSL Certificate Authority file
 
 [id="plugins-{type}s-{plugin}-enable_sort"]
-===== `enable_sort` 
+===== `enable_sort`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 Whether results should be sorted or not
 
-[id="plugins-{type}s-{plugin}-fields"]
-===== `fields` 
+[id="plugins-{type}s-{plugin}-docinfo_fields"]
+===== `docinfo_fields`
 
-  * Value type is <<array,array>>
+  * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Array of fields to copy from old event (found via elasticsearch) into new event
+Hash of metadata fields to copy from old event (found via elasticsearch) into new event. See
+[Document Metadata](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_document_metadata.html)
+in the Elasticsearch documentation for more information.
+
+Example:
+[source,ruby]
+    filter {
+      elasticsearch {
+        docinfo_fields => {
+          "_id" => "document_id"
+          "_index" => "document_index"
+        }
+      }
+    }
+
+[id="plugins-{type}s-{plugin}-fields"]
+===== `fields`
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+Hash of fields to copy from old event (found via elasticsearch) into new event
 
 [id="plugins-{type}s-{plugin}-hosts"]
-===== `hosts` 
+===== `hosts`
 
   * Value type is <<array,array>>
   * Default value is `["localhost:9200"]`
@@ -158,7 +180,7 @@ Array of fields to copy from old event (found via elasticsearch) into new event
 List of elasticsearch hosts to use for querying.
 
 [id="plugins-{type}s-{plugin}-index"]
-===== `index` 
+===== `index`
 
   * Value type is <<string,string>>
   * Default value is `""`
@@ -167,7 +189,7 @@ Comma-delimited list of index names to search; use `_all` or empty string to per
 Field substitution (e.g. `index-name-%{date_field}`) is available
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password` 
+===== `password`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -175,7 +197,7 @@ Field substitution (e.g. `index-name-%{date_field}`) is available
 Basic Auth - password
 
 [id="plugins-{type}s-{plugin}-query"]
-===== `query` 
+===== `query`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -184,7 +206,7 @@ Elasticsearch query string. Read the Elasticsearch query string documentation.
 for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
 
 [id="plugins-{type}s-{plugin}-query_template"]
-===== `query_template` 
+===== `query_template`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -193,7 +215,7 @@ File path to elasticsearch query in DSL format. Read the Elasticsearch query doc
 for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 
 [id="plugins-{type}s-{plugin}-result_size"]
-===== `result_size` 
+===== `result_size`
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -201,7 +223,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/curren
 How many results to return
 
 [id="plugins-{type}s-{plugin}-sort"]
-===== `sort` 
+===== `sort`
 
   * Value type is <<string,string>>
   * Default value is `"@timestamp:desc"`
@@ -209,7 +231,7 @@ How many results to return
 Comma-delimited list of `<field>:<direction>` pairs that define the sort order
 
 [id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl` 
+===== `ssl`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -217,7 +239,7 @@ Comma-delimited list of `<field>:<direction>` pairs that define the sort order
 SSL
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
-===== `tag_on_failure` 
+===== `tag_on_failure`
 
   * Value type is <<array,array>>
   * Default value is `["_elasticsearch_lookup_failure"]`
@@ -225,7 +247,7 @@ SSL
 Tags the event on failure to look up previous log event information. This can be used in later analysis.
 
 [id="plugins-{type}s-{plugin}-user"]
-===== `user` 
+===== `user`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -103,11 +103,11 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Comma-delimited list of `<field>:<direction>` pairs that define the sort order
   config :sort, :validate => :string, :default => "@timestamp:desc"
 
-  # Hash of fields to copy from old event (found via elasticsearch) into new event
-  config :fields, :validate => :hash, :default => {}
+  # Array of fields to copy from old event (found via elasticsearch) into new event
+  config :fields, :validate => :array, :default => {}
 
-  # Hash of document metadata fields copy from old event (found via elasticsearch) into new event
-  config :docinfo_fields, :validate => :hash, :default => {}
+  # Array of document metadata fields copy from old event (found via elasticsearch) into new event
+  config :docinfo_fields, :validate => :array, :default => {}
 
   # Basic Auth - username
   config :user, :validate => :string

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -3,6 +3,7 @@ require "logstash/filters/base"
 require "logstash/namespace"
 require_relative "elasticsearch/client"
 require "logstash/json"
+java_import "java.util.concurrent.ConcurrentHashMap"
 
 # .Compatibility Note
 # [NOTE]
@@ -88,6 +89,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   config :hosts, :validate => :array,  :default => [ "localhost:9200" ]
 
   # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices
+  # Field substitution (e.g. `index-name-%{date_field}`) is available
   config :index, :validate => :string, :default => ""
 
   # Elasticsearch query string. Read the Elasticsearch query string documentation.
@@ -128,14 +130,10 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Tags the event on failure to look up geo information. This can be used in later analysis.
   config :tag_on_failure, :validate => :array, :default => ["_elasticsearch_lookup_failure"]
 
+  attr_reader :clients_pool
+
   def register
-    options = {
-      :ssl => @ssl,
-      :hosts => @hosts,
-      :ca_file => @ca_file,
-      :logger => @logger
-    }
-    @client = LogStash::Filters::ElasticsearchClient.new(@user, @password, options)
+    @clients_pool = java.util.concurrent.ConcurrentHashMap.new
 
     #Load query if it exists
     if @query_template
@@ -151,7 +149,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   def filter(event)
     begin
 
-      params = {:index => @index }
+      params = {:index => event.sprintf(@index) }
 
       if @query_dsl
         query = LogStash::Json.load(event.sprintf(@query_dsl))
@@ -165,7 +163,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
       @logger.debug("Querying elasticsearch for lookup", :params => params)
 
-      results = @client.search(params)
+      results = get_client.search(params)
       @fields.each do |old_key, new_key|
         if !results['hits']['hits'].empty?
           set = []
@@ -190,4 +188,22 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     end
     filter_matched(event)
   end # def filter
+
+  private
+  def client_options
+    {
+      :ssl => @ssl,
+      :hosts => @hosts,
+      :ca_file => @ca_file,
+      :logger => @logger
+    }
+  end
+
+  def new_client
+    LogStash::Filters::ElasticsearchClient.new(@user, @password, client_options)
+  end
+
+  def get_client
+    @clients_pool.computeIfAbsent(Thread.current, lambda { |x| new_client })
+  end
 end #class LogStash::Filters::Elasticsearch

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -11,9 +11,9 @@ require "logstash/json"
 # called `http.content_type.required`. If this option is set to `true`, and you
 # are using Logstash 2.4 through 5.2, you need to update the Elasticsearch filter
 # plugin to version 3.1.1 or higher.
-# 
+#
 # ================================================================================
-# 
+#
 # Search Elasticsearch for a previous log event and copy some fields from it
 # into the current event.  Below are two complete examples of how this filter might
 # be used.
@@ -86,7 +86,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array,  :default => [ "localhost:9200" ]
-  
+
   # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices
   config :index, :validate => :string, :default => ""
 
@@ -103,6 +103,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # Array of fields to copy from old event (found via elasticsearch) into new event
   config :fields, :validate => :array, :default => {}
+
+  # Array of meta-fields to copy from old event (found via elasticsearch) into new event
+  config :meta_fields, :validate => :array, :default => {}
 
   # Basic Auth - username
   config :user, :validate => :string
@@ -168,6 +171,15 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
           set = []
           results["hits"]["hits"].to_a.each do |doc|
             set << doc["_source"][old_key]
+          end
+          event.set(new_key, set.count > 1 ? set : set.first)
+        end
+      end
+      @meta_fields.each do |old_key, new_key|
+        if !results['hits']['hits'].empty?
+          set = []
+          results["hits"]["hits"].to_a.each do |doc|
+            set << doc[old_key]
           end
           event.set(new_key, set.count > 1 ? set : set.first)
         end

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -88,7 +88,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # List of elasticsearch hosts to use for querying.
   config :hosts, :validate => :array,  :default => [ "localhost:9200" ]
 
-  # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices
+  # Comma-delimited list of index names to search; use `_all` or empty string to perform the operation on all indices.
   # Field substitution (e.g. `index-name-%{date_field}`) is available
   config :index, :validate => :string, :default => ""
 
@@ -103,11 +103,11 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Comma-delimited list of `<field>:<direction>` pairs that define the sort order
   config :sort, :validate => :string, :default => "@timestamp:desc"
 
-  # Array of fields to copy from old event (found via elasticsearch) into new event
-  config :fields, :validate => :array, :default => {}
+  # Hash of fields to copy from old event (found via elasticsearch) into new event
+  config :fields, :validate => :hash, :default => {}
 
-  # Array of meta-fields to copy from old event (found via elasticsearch) into new event
-  config :meta_fields, :validate => :array, :default => {}
+  # Hash of document metadata fields copy from old event (found via elasticsearch) into new event
+  config :docinfo_fields, :validate => :hash, :default => {}
 
   # Basic Auth - username
   config :user, :validate => :string
@@ -173,7 +173,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
           event.set(new_key, set.count > 1 ? set : set.first)
         end
       end
-      @meta_fields.each do |old_key, new_key|
+      @docinfo_fields.each do |old_key, new_key|
         if !results['hits']['hits'].empty?
           set = []
           results["hits"]["hits"].to_a.each do |doc|


### PR DESCRIPTION
This closes #57 by adding a meta_fields config to extract [event meta-fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html)