### PR TITLE
Support ca_file setting when using https uri in hosts parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.5
  - Docs: Fix broken link to Logstash docs.
+ - Support ca_file setting when using https uri in hosts parameter
 
 ## 3.1.4
  - Docs: Bump patch level for doc build.

--- a/lib/logstash/filters/elasticsearch/client.rb
+++ b/lib/logstash/filters/elasticsearch/client.rb
@@ -21,7 +21,8 @@ module LogStash
         end
 
         hosts.map! {|h| { host: h, scheme: 'https' } } if ssl
-        transport_options[:ssl] = { ca_file: options[:ca_file] } if ssl && options[:ca_file]
+        # set ca_file even if ssl isn't on, since the host can be an https url
+        transport_options[:ssl] = { ca_file: options[:ca_file] } if options[:ca_file]
 
         @logger.info("New ElasticSearch filter", :hosts => hosts)
         @client = ::Elasticsearch::Client.new(hosts: hosts, transport_options: transport_options)


### PR DESCRIPTION
Currently if the hosts parameter has an https url but ssl isn't set
to true, ssl will be used but the ca_file setting is ignored.
This commit ensures ca_file is set if is declared, regardless of the
value of the ssl parameter

partially fixes https://github.com/logstash-plugins/logstash-filter-elasticsearch/issues/58