### PR TITLE
Query error and nested field

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -145,7 +145,6 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   def filter(event)
     begin
-
       params = {:index => event.sprintf(@index) }
 
       if @query_dsl
@@ -161,6 +160,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       @logger.debug("Querying elasticsearch for lookup", :params => params)
 
       results = get_client.search(params)
+      raise "Elasticsearch query error: #{results["_shards"]["failures"]}" if results["_shards"].include? "failures"
+
       @fields.each do |old_key, new_key|
         if !results['hits']['hits'].empty?
           old_key_path = extract_path(old_key)

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -162,6 +162,21 @@ describe LogStash::Filters::Elasticsearch do
         expect(client).to receive(:search).with({:q => "response: 404", :size => 1, :index => "foo_subst_value*", :sort => "@timestamp:desc"})
         plugin.filter(event)
       end
+    end
+
+    context "if query is on nested field" do
+      let(:config) do
+        {
+            "hosts" => ["localhost:9200"],
+            "query" => "response: 404",
+            "fields" => [ ["[geoip][ip]", "ip_address"] ]
+        }
+      end
+
+      it "should enhance the current event with new data" do
+        plugin.filter(event)
+        expect(event.get("ip_address")).to eq("66.249.73.185")
+      end
 
     end
 

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -164,6 +164,24 @@ describe LogStash::Filters::Elasticsearch do
       end
     end
 
+    context "if query result errored but no exception is thrown" do
+      let(:response) do
+        LogStash::Json.load(File.read(File.join(File.dirname(__FILE__), "fixtures", "request_error.json")))
+      end
+
+      before(:each) do
+        allow(LogStash::Filters::ElasticsearchClient).to receive(:new).and_return(client)
+        allow(client).to receive(:search).and_return(response)
+        plugin.register
+      end
+
+      it "tag the event as something happened, but still deliver it" do
+        expect(plugin.logger).to receive(:warn)
+        plugin.filter(event)
+        expect(event.to_hash["tags"]).to include("_elasticsearch_lookup_failure")
+      end
+    end
+
     context "if query is on nested field" do
       let(:config) do
         {

--- a/spec/filters/fixtures/request_error.json
+++ b/spec/filters/fixtures/request_error.json
@@ -1,0 +1,25 @@
+{
+	"took": 16,
+	"timed_out": false,
+	"_shards": {
+		"total": 155,
+		"successful": 100,
+		"failed": 55,
+		"failures": [
+			{
+				"shard": 0,
+				"index": "logstash-2014.08.26",
+				"node": "YI1MT0H-Q469pFgAVTXI2g",
+				"reason": {
+					"type": "search_parse_exception",
+					"reason": "No mapping found for [@timestamp] in order to sort on"
+				}
+			}
+		]
+	},
+	"hits": {
+		"total": 0,
+		"max_score": null,
+		"hits": []
+	}
+}


### PR DESCRIPTION
This PR picks up where we left @samwoods1 hanging on #45, rebases it, and does a minor refactor for clarity; I'm opening as a separate PR so I can push it through without making the original PR author keep doing the rebase dance.

 1. if the response indicates that the elasticsearch shards are in error, don't silently fail
 2. when the "old field" is be a `[path][reference]`, crawl the result document to extract the value at the given path