### PR TITLE
Correct the query_template fields copy

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -67,6 +67,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
          elasticsearch {
             hosts => ["es-server"]
             query_template => "template.json"
+            fields => { "@timestamp" => "started" }
          }
 
          date {
@@ -89,7 +90,7 @@ the "end" event.  Finally, using a combination of the "date" filter and the
        "query": "type:start AND operation:%{[opid]}"
       }
     },
-   "_source": ["@timestamp", "started"]
+   "_source": ["@timestamp"]
  }
 
 As illustrated above, through the use of 'opid', fields from the Logstash events can be referenced within the template.


### PR DESCRIPTION
When using a query template in the Elasticsearch filter plugin, the fields wanted from an old Elasticsearch event still must be explicitly indicated in the configuration file, so these fields can be copied to the new event. In the query template itself you can't indicate the new field as stated in the documentation in the "_source" field, but only the field being copied from the old event living in Elasticsearch.

Tested on Logstash 6.1.1 and Elasticsearch 6.1.1, the configuration example written in the documentation doesn't work.

First spotted by the user VittorioP in this thread:
https://discuss.elastic.co/t/how-to-query-elasticsearch-and-take-some-fields-from-old-data/75300/3

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
