### PR TITLE
Add documentation about query_template vs size & sort

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -61,8 +61,9 @@ if [type] == "end" {
 }
 --------------------------------------------------
 
-The example below reproduces the above example but utilises the query_template.  This query_template represents a full
-Elasticsearch query DSL and supports the standard Logstash field substitution syntax.  The example below issues
+The example below reproduces the above example but utilises the query_template.
+This query_template represents a full Elasticsearch query DSL and supports the
+standard Logstash field substitution syntax.  The example below issues
 the same query as the first example but uses the template shown.
 
 [source,ruby]
@@ -99,7 +100,8 @@ template.json:
  }
 --------------------------------------------------
 
-As illustrated above, through the use of 'opid', fields from the Logstash events can be referenced within the template.
+As illustrated above, through the use of 'opid', fields from the Logstash
+events can be referenced within the template.
 The template will be populated per event prior to being used to query Elasticsearch.
 
 Note that when using `query_template, the Logstash attributes `result_size`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -102,6 +102,25 @@ template.json:
 As illustrated above, through the use of 'opid', fields from the Logstash events can be referenced within the template.
 The template will be populated per event prior to being used to query Elasticsearch.
 
+Note that when using `query_template, the Logstash attributes `result_size`
+and `sort` will be ignored. They should be specified directly in the JSON
+template. Example:
+
+[source,json]
+--------------------------------------------------
+{
+  "size": 1,
+  "sort" : [ { "@timestamp" : "desc" } ],
+  "query": {
+    "query_string": {
+      "query": "type:start AND operation:%{[opid]}"
+    }
+  },
+  "_source": ["@timestamp"]
+}
+--------------------------------------------------
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Filter Configuration Options
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -104,7 +104,7 @@ As illustrated above, through the use of 'opid', fields from the Logstash
 events can be referenced within the template.
 The template will be populated per event prior to being used to query Elasticsearch.
 
-Note that when using `query_template, the Logstash attributes `result_size`
+Note that when you use `query_template`, the Logstash attributes `result_size`
 and `sort` will be ignored. They should be specified directly in the JSON
 template. Example:
 


### PR DESCRIPTION
In this PR I intentionally avoid fixing the text in the query_template example,
which will be fixed by #88.

Contributes to #96.
Closes #64.