### PR TITLE
Add 'total_hits' field to @metadata

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -93,6 +93,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       results = get_client.search(params)
       raise "Elasticsearch query error: #{results["_shards"]["failures"]}" if results["_shards"].include? "failures"
 
+      event.set("[@metadata][total_hits]", results['hits']['total'])
+
       resultsHits = results["hits"]["hits"]
       if !resultsHits.nil? && !resultsHits.empty?
         matched = true


### PR DESCRIPTION
When a search succeeds, add a field 'total_hits' to the events metadata that stores the number of matched documents.