### PR TITLE
Option to include full list of hits

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -126,6 +126,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-cloud_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-docinfo_fields>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-enable_sort>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-include_hits>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-fields>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
@@ -190,12 +191,20 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-enable_sort"]
-===== `enable_sort` 
+===== `enable_sort`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 Whether results should be sorted or not
+
+[id="plugins-{type}s-{plugin}-include_hits"]
+===== `include_hits`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Whether the full list of hits should be applied to `[@metadata][hits]`.
 
 [id="plugins-{type}s-{plugin}-fields"]
 ===== `fields` 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -64,6 +64,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Whether results should be sorted or not
   config :enable_sort, :validate => :boolean, :default => true
 
+  # Whether to set hits to metadata
+  config :include_hits, :validate => :boolean, :default => true
+
   # How many results to return
   config :result_size, :validate => :number, :default => 1
 
@@ -116,6 +119,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
       resultsHits = results["hits"]["hits"]
       if !resultsHits.nil? && !resultsHits.empty?
+        if @include_hits
+          event.set("[@metadata][hits]", resultsHits)
+        end
         matched = true
         @fields.each do |old_key, new_key|
           old_key_path = extract_path(old_key)

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -65,7 +65,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   config :enable_sort, :validate => :boolean, :default => true
 
   # Whether to set hits to metadata
-  config :include_hits, :validate => :boolean, :default => true
+  config :include_hits, :validate => :boolean, :default => false
 
   # How many results to return
   config :result_size, :validate => :number, :default => 1


### PR DESCRIPTION
# Background information

We needed to process the full list of hits that the elastic search plugin retrieved, but the plugin is design to only assign fields and not the whole result set.

# Feature description

Setting `include_hits` to  `true` (it defaults to false) will cause the plugin to add the hits to `[@metadata][hits]`.

