### PR TITLE
Doc: Update links to logstash-to-cloud docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.9.2
+  - [DOC] Fixed links to restructured Logstash-to-cloud docs [#142](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/142)
+
 ## 3.9.1
   - [DOC] Document the permissions required in secured clusters [#140](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/140)
   

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,5 @@
 :plugin: elasticsearch
 :type: filter
-:branch: current
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -180,7 +179,7 @@ Authenticate using Elasticsearch API key. Note that this option also requires en
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
 Elasticsearch
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create
 API key API].
 
 [id="plugins-{type}s-{plugin}-proxy"]
@@ -282,7 +281,7 @@ Basic Auth - password
 
 Elasticsearch query string. Read the Elasticsearch query string documentation.
 for more info at:
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-query-string-query.html#query-string-syntax
+https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax
 
 [id="plugins-{type}s-{plugin}-query_template"]
 ===== `query_template` 
@@ -291,7 +290,7 @@ https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-query
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 
 [id="plugins-{type}s-{plugin}-result_size"]
 ===== `result_size` 
@@ -342,7 +341,7 @@ Basic Auth - username
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
 documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
@@ -354,7 +353,7 @@ documentation]
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
 documentation]
 
 
@@ -362,4 +361,3 @@ documentation]
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -335,7 +335,7 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,7 +345,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -360,4 +360,3 @@ documentation]
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
-

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -182,16 +182,6 @@ Elasticsearch
 https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create
 API key API].
 
-[id="plugins-{type}s-{plugin}-proxy"]
-===== `proxy`
-
-* Value type is <<uri,uri>>
-* There is no default value for this setting.
-
-Set the address of a forward HTTP proxy.
-An empty string is treated as if proxy was not set, and is useful when using
-environment variables e.g. `proxy => '${LS_PROXY:}'`.
-
 [id="plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file` 
 
@@ -199,6 +189,30 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * There is no default value for this setting.
 
 SSL Certificate Authority file
+
+[id="plugins-{type}s-{plugin}-cloud_auth"]
+===== `cloud_auth`
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
+
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
+documentation].
+
+[id="plugins-{type}s-{plugin}-cloud_id"]
+===== `cloud_id`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
+
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
+documentation].
 
 [id="plugins-{type}s-{plugin}-docinfo_fields"]
 ===== `docinfo_fields` 
@@ -273,6 +287,16 @@ Field substitution (e.g. `index-name-%{date_field}`) is available
 
 Basic Auth - password
 
+[id="plugins-{type}s-{plugin}-proxy"]
+===== `proxy`
+
+* Value type is <<uri,uri>>
+* There is no default value for this setting.
+
+Set the address of a forward HTTP proxy.
+An empty string is treated as if proxy was not set, and is useful when using
+environment variables e.g. `proxy => '${LS_PROXY:}'`.
+
 [id="plugins-{type}s-{plugin}-query"]
 ===== `query` 
 
@@ -331,31 +355,6 @@ Tags the event on failure to look up previous log event information. This can be
   * There is no default value for this setting.
 
 Basic Auth - username
-
-[id="plugins-{type}s-{plugin}-cloud_auth"]
-===== `cloud_auth`
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
-
-For more info, check out the
-https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
-documentation]
-
-[id="plugins-{type}s-{plugin}-cloud_id"]
-===== `cloud_id`
-
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
-
-For more info, check out the
-https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
-documentation]
-
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,6 @@
 :plugin: elasticsearch
 :type: filter
+:branch: current
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -24,7 +25,8 @@ Search Elasticsearch for a previous log event and copy some fields from it
 into the current event. Below are two complete examples of how this filter might
 be used.
 
-The first example uses the legacy 'query' parameter where the user is limited to an Elasticsearch query_string.
+The first example uses the legacy 'query' parameter where the user is limited to
+an Elasticsearch query_string.
 Whenever logstash receives an "end" event, it uses this elasticsearch
 filter to find the matching "start" event based on some operation identifier.
 Then it copies the `@timestamp` field from the "start" event into a new field on
@@ -176,7 +178,10 @@ Example:
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+API key API].
 
 [id="plugins-{type}s-{plugin}-proxy"]
 ===== `proxy`
@@ -276,7 +281,8 @@ Basic Auth - password
   * There is no default value for this setting.
 
 Elasticsearch query string. Read the Elasticsearch query string documentation.
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
+for more info at:
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-query-string-query.html#query-string-syntax
 
 [id="plugins-{type}s-{plugin}-query_template"]
 ===== `query_template` 
@@ -285,7 +291,7 @@ for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master
   * There is no default value for this setting.
 
 File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
-for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 
 [id="plugins-{type}s-{plugin}-result_size"]
 ===== `result_size` 
@@ -335,7 +341,9 @@ Basic Auth - username
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -345,9 +353,13 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+documentation]
 
 
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+
+:branch!:

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.9.1'
+  s.version         = '3.9.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
[Cloud rework](https://github.com/elastic/logstash/pull/11884) broke some links from the plugins. This PR updates the links and points one level up in docs to give user a bit more context for logstash->cloud.

Fixes: #141 
