### PR TITLE
ci: use `docker_pull` to source images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
 
 env:
-  - INTEGRATION=false ELASTIC_STACK_VERSION=5.x
   - INTEGRATION=false ELASTIC_STACK_VERSION=6.x
   - INTEGRATION=false ELASTIC_STACK_VERSION=7.x
   - INTEGRATION=true ELASTIC_STACK_VERSION=6.x


### PR DESCRIPTION
Mirrors work done in upstream's `docker-setup` (https://github.com/logstash-plugins/.ci/pull/20) and returns integration tests to green.