### PR TITLE
Doc: Add space delimited URI examples to `hosts` option

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -267,6 +267,17 @@ fields => {
 
 List of elasticsearch hosts to use for querying.
 
+This option can accept an environment variable containing one or more hostnames separated by whitespace.
+Strings separated by whitespace are treated as separate entries.
+
+*Examples:*
+
+* `ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"`
+* `ES_HOSTS="127.0.0.1:9200 127.0.0.2:9200"`
+* `ES_HOSTS="http://127.0.0.1 http://127.0.0.2"`
+* `ES_HOSTS="https://127.0.0.1:9200/mypath https://127.0.0.2:9200/mypath"`
+
+
 [id="plugins-{type}s-{plugin}-index"]
 ===== `index` 
 


### PR DESCRIPTION
Improve documentation by adding meaningful examples
