### PR TITLE
Fixed SSL handshake hang indefinitely with proxy setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.9.5
-  - Fixed SSL handshake hang indefinitely with proxy setup
+  - Fixed SSL handshake hang indefinitely with proxy setup [#151](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/151)
 
 ## 3.9.4
   - Fix: a regression (in LS 7.14.0) where due the elasticsearch client update (from 5.0.5 to 7.5.0) the `Authorization` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.9.5
+  - Fixed SSL handshake hang indefinitely with proxy setup
+
 ## 3.9.4
   - Fix: a regression (in LS 7.14.0) where due the elasticsearch client update (from 5.0.5 to 7.5.0) the `Authorization` 
     header isn't passed, this leads to the plugin not being able to leverage `user`/`password` credentials set by the user.

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.9.4'
+  s.version         = '3.9.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'elasticsearch', ">= 5.0.5" # LS >= 6.7 and < 7.14 all used version 5.0.5
-  s.add_runtime_dependency 'manticore', "~> 0.6"
+  s.add_runtime_dependency 'manticore', ">= 0.7.1"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
the fix in upstream has merged and [released](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1032#issuecomment-900782420) in 0.7.1 gem
Hence, update manticore

Fix: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1033
Related: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1032
