### PR TITLE
add ES PKI authentication support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -110,6 +110,7 @@ Authentication to a secure Elasticsearch cluster is possible using _one_ of the 
 * <<plugins-{type}s-{plugin}-user>> AND <<plugins-{type}s-{plugin}-password>>
 * <<plugins-{type}s-{plugin}-cloud_auth>>
 * <<plugins-{type}s-{plugin}-api_key>>
+* <<plugins-{type}s-{plugin}-keystore>> and/or <<plugins-{type}s-{plugin}-keystore_password>>
 
 [id="plugins-{type}s-{plugin}-autz"]
 ==== Authorization
@@ -143,6 +144,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-result_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sort>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
@@ -347,6 +350,22 @@ Comma-delimited list of `<field>:<direction>` pairs that define the sort order
   * Default value is `false`
 
 SSL
+
+[id="plugins-{type}s-{plugin}-keystore"]
+===== `keystore` 
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The keystore used to present a certificate to the server. It can be either .jks or .p12
+
+[id="plugins-{type}s-{plugin}-keystore_password"]
+===== `keystore_password` 
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Set the keystore password
 
 [id="plugins-{type}s-{plugin}-tag_on_failure"]
 ===== `tag_on_failure` 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -66,6 +66,13 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # SSL Certificate Authority file
   config :ca_file, :validate => :path
 
+  # The keystore used to present a certificate to the server.
+  # It can be either .jks or .p12
+  config :keystore, :validate => :path
+
+  # Set the keystore password
+  config :keystore_password, :validate => :password
+
   # Whether results should be sorted or not
   config :enable_sort, :validate => :boolean, :default => true
 
@@ -204,6 +211,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       :proxy => @proxy,
       :ssl => @ssl,
       :ca_file => @ca_file,
+      :keystore => @keystore,
+      :keystore_password => @keystore_password,
       :ssl_trust_strategy => trust_strategy_for_ca_trusted_fingerprint
     }
   end

--- a/lib/logstash/filters/elasticsearch/client.rb
+++ b/lib/logstash/filters/elasticsearch/client.rb
@@ -12,6 +12,8 @@ module LogStash
 
       def initialize(logger, hosts, options = {})
         ssl = options.fetch(:ssl, false)
+        keystore = options.fetch(:keystore, nil)
+        keystore_password = options.fetch(:keystore_password, nil)
         user = options.fetch(:user, nil)
         password = options.fetch(:password, nil)
         api_key = options.fetch(:api_key, nil)
@@ -32,6 +34,12 @@ module LogStash
         # set ca_file even if ssl isn't on, since the host can be an https url
         ssl_options.update(ssl: true, ca_file: options[:ca_file]) if options[:ca_file]
         ssl_options.update(ssl: true, trust_strategy: options[:ssl_trust_strategy]) if options[:ssl_trust_strategy]
+
+        if keystore
+          ssl_options[:keystore] = keystore
+          logger.info("Keystore for client certificate", :keystore => keystore)
+          ssl_options[:keystore_password] = keystore_password.value if keystore_password
+        end
 
         logger.info("New ElasticSearch filter client", :hosts => hosts)
         @client = ::Elasticsearch::Client.new(hosts: hosts, transport_options: transport_options, transport_class: ::Elasticsearch::Transport::Transport::HTTP::Manticore, :ssl => ssl_options)


### PR DESCRIPTION
This PR add the ability to use ES PKI authentication in the same way the Elasticsearch output filter do.