### PR TITLE
avoid holding refs to threads, rely on manticore threadsafety

### DIFF
--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -24,9 +24,9 @@ wait_for_es() {
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
-  jruby -rbundler/setup -S rspec -fd -t ~integration spec/filters
+  bundle exec rspec --format=documentation -t ~integration spec/filters
 else
   extra_tag_args="-t integration"
   wait_for_es
-  jruby -rbundler/setup -S rspec -fd $extra_tag_args -t es_version:$ELASTIC_STACK_VERSION spec/filters/integration
+  bundle exec  rspec --format=documentation $extra_tag_args -t es_version:$ELASTIC_STACK_VERSION spec/filters/integration
 fi

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -91,7 +91,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # config :ca_trusted_fingerprint, :validate => :sha_256_hex
   include LogStash::PluginMixins::CATrustedFingerprintSupport
 
-  attr_reader :clients_pool
+  attr_reader :shared_client
 
   ##
   # @override to handle proxy => '' as if none was set
@@ -111,7 +111,6 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   end
 
   def register
-    @clients_pool = java.util.concurrent.ConcurrentHashMap.new
 
     #Load query if it exists
     if @query_template
@@ -240,7 +239,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   end
 
   def get_client
-    @clients_pool.computeIfAbsent(Thread.current, lambda { |x| new_client })
+    @shared_client ||= new_client
   end
 
   # get an array of path elements from a path reference


### PR DESCRIPTION
Since our transport class Manticore is explicitly threadsafe and by default creates a pool with up to 50 connections, we do not need an individual client instance per worker thread.

Using a shared instance also closes a memory leak that was caused by using a strong reference to the thread itself as a key in the routing to per-thread clients, which was not cleaned up on pipeline failure or completion.