### PR TITLE
fix: restore use of DefaultHostnameVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.15.1
+  - Fixes a regression introduced in 3.15.0 which could prevent a connection from being established to Elasticsearch in some SSL configurations
+
 ## 3.15.0
   - Added SSL settings for: [#168](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/168)
     - `ssl_enabled`: Enable/disable the SSL settings. If not provided, the value is inferred from the hosts scheme

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -317,7 +317,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
                         "to make sure your data is secure set `ssl_verification_mode => full`"
           ssl_options[:verify] = :disable
         else
-          ssl_options[:verify] = :strict
+          # Manticore's :default maps to Apache HTTP Client's DefaultHostnameVerifier,
+          # which is the modern STRICT verifier that replaces the deprecated StrictHostnameVerifier
+          ssl_options[:verify] = :default
       end
     end
 

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.15.0'
+  s.version         = '3.15.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/elasticsearch_ssl_spec.rb
+++ b/spec/filters/elasticsearch_ssl_spec.rb
@@ -122,7 +122,7 @@ describe "SSL options" do
 
       it "should pass the flag to the ES client" do
         expect(::Elasticsearch::Client).to receive(:new) do |args|
-          expect(args[:ssl]).to match hash_including(:enabled => true, :verify => :strict)
+          expect(args[:ssl]).to match hash_including(:enabled => true, :verify => :default)
         end.and_return(es_client_double)
 
         subject.register
@@ -199,7 +199,7 @@ describe "SSL options" do
                                       :truststore => ssl_truststore_path,
                                       :truststore_type => "jks",
                                       :truststore_password => "foo",
-                                      :verify => :strict,
+                                      :verify => :default,
                                       :cipher_suites => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
                                       :protocols => ["TLSv1.3"],
                                     )
@@ -235,7 +235,7 @@ describe "SSL options" do
                                       :ca_file => ssl_certificate_authorities_path,
                                       :client_cert => ssl_certificate_path,
                                       :client_key => ssl_key_path,
-                                      :verify => :strict,
+                                      :verify => :default,
                                       :cipher_suites => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
                                       :protocols => ["TLSv1.3"],
                                     )


### PR DESCRIPTION
equivalent to https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/193