### PR TITLE
validate query and query_template settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.15.2
-  - Added default value `*` to `query`.
+  - Added default value `*` to `query`. [#171](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/171)
   
 ## 3.15.1
   - Fixes a regression introduced in 3.15.0 which could prevent a connection from being established to Elasticsearch in some SSL configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.15.2
+  - Added default value `*` to `query`.
+  
 ## 3.15.1
   - Fixes a regression introduced in 3.15.0 which could prevent a connection from being established to Elasticsearch in some SSL configurations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.15.2
-  - Added default value `*` to `query`. [#171](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/171)
+  - Added checking for `query` and `query_template`. [#171](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/171)
   
 ## 3.15.1
   - Fixes a regression introduced in 3.15.0 which could prevent a connection from being established to Elasticsearch in some SSL configurations

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -315,11 +315,12 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
 ===== `query` 
 
   * Value type is <<string,string>>
-  * Default value is `*`.
+  * There is no default value for this setting.
 
 Elasticsearch query string. More information is available in the
 {ref}/query-dsl-query-string-query.html#query-string-syntax[Elasticsearch query
 string documentation].
+Either `query` or `query_template` is mandatory.
 
 
 [id="plugins-{type}s-{plugin}-query_template"]
@@ -330,6 +331,7 @@ string documentation].
 
 File path to elasticsearch query in DSL format. More information is available in
 the {ref}/query-dsl.html[Elasticsearch query documentation].
+Either `query` or `query_template` is mandatory.
 
 [id="plugins-{type}s-{plugin}-result_size"]
 ===== `result_size` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -320,7 +320,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
 Elasticsearch query string. More information is available in the
 {ref}/query-dsl-query-string-query.html#query-string-syntax[Elasticsearch query
 string documentation].
-Either `query` or `query_template` is mandatory.
+Use either `query` or `query_template`.
 
 
 [id="plugins-{type}s-{plugin}-query_template"]
@@ -331,7 +331,7 @@ Either `query` or `query_template` is mandatory.
 
 File path to elasticsearch query in DSL format. More information is available in
 the {ref}/query-dsl.html[Elasticsearch query documentation].
-Either `query` or `query_template` is mandatory.
+Use either `query` or `query_template`.
 
 [id="plugins-{type}s-{plugin}-result_size"]
 ===== `result_size` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -315,7 +315,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
 ===== `query` 
 
   * Value type is <<string,string>>
-  * There is no default value for this setting.
+  * Default value is `*`.
 
 Elasticsearch query string. More information is available in the
 {ref}/query-dsl-query-string-query.html#query-string-syntax[Elasticsearch query

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -20,7 +20,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # Elasticsearch query string. Read the Elasticsearch query string documentation.
   # for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
-  config :query, :validate => :string, :default => "*"
+  config :query, :validate => :string
 
   # File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
   # for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
@@ -170,6 +170,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
       @query_dsl = file.read
     end
 
+    validate_query_settings
     fill_hosts_from_cloud_id
     setup_ssl_params!
     validate_authentication
@@ -389,6 +390,16 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   def hosts_default?(hosts)
     hosts.is_a?(Array) && hosts.size == 1 && !original_params.key?('hosts')
+  end
+
+  def validate_query_settings
+    unless @query || @query_template
+      raise LogStash::ConfigurationError, "Both `query` and `query_template` are empty. Please either set `query` or `query_template`."
+    end
+
+    if @query && @query_template
+      raise LogStash::ConfigurationError, "Both `query` and `query_template` are set. Please either set `query` or `query_template`."
+    end
   end
 
   def validate_authentication

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -394,11 +394,11 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   def validate_query_settings
     unless @query || @query_template
-      raise LogStash::ConfigurationError, "Both `query` and `query_template` are empty. Please either set `query` or `query_template`."
+      raise LogStash::ConfigurationError, "Both `query` and `query_template` are empty. Require either `query` or `query_template`."
     end
 
     if @query && @query_template
-      raise LogStash::ConfigurationError, "Both `query` and `query_template` are set. Please either set `query` or `query_template`."
+      raise LogStash::ConfigurationError, "Both `query` and `query_template` are set. Use either `query` or `query_template`."
     end
   end
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -398,7 +398,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     end
 
     if @query && @query_template
-      @logger.warn("Both `query` and `query_template` are set. `query_template` will take the precedence over `query`.")
+      raise LogStash::ConfigurationError, "Both `query` and `query_template` are set. Use either `query` or `query_template`."
     end
   end
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -398,7 +398,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     end
 
     if @query && @query_template
-      raise LogStash::ConfigurationError, "Both `query` and `query_template` are set. Use either `query` or `query_template`."
+      @logger.warn("Both `query` and `query_template` are set. `query_template` will take the precedence over `query`.")
     end
   end
 

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -20,7 +20,7 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
 
   # Elasticsearch query string. Read the Elasticsearch query string documentation.
   # for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
-  config :query, :validate => :string
+  config :query, :validate => :string, :default => "*"
 
   # File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
   # for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.15.1'
+  s.version         = '3.15.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -55,10 +55,12 @@ describe LogStash::Filters::Elasticsearch do
         expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
       end
 
-      it "raise an exception when query and query_template are set" do
+      it "gives warning when query and query_template are set" do
         config = { "query" => "*", "query_template" => File.join(File.dirname(__FILE__), "fixtures", "query_template_unicode.json") }
         plugin = described_class.new(config)
-        expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
+        allow(plugin).to receive(:test_connection!)
+        expect(plugin.logger).to receive(:warn)
+        plugin.register
       end
     end
   end

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -55,12 +55,10 @@ describe LogStash::Filters::Elasticsearch do
         expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
       end
 
-      it "gives warning when query and query_template are set" do
+      it "raise an exception when query and query_template are set" do
         config = { "query" => "*", "query_template" => File.join(File.dirname(__FILE__), "fixtures", "query_template_unicode.json") }
         plugin = described_class.new(config)
-        allow(plugin).to receive(:test_connection!)
-        expect(plugin.logger).to receive(:warn)
-        plugin.register
+        expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
       end
     end
   end

--- a/spec/filters/elasticsearch_ssl_spec.rb
+++ b/spec/filters/elasticsearch_ssl_spec.rb
@@ -36,7 +36,8 @@ describe "SSL options" do
     context "false and cloud_id resolved host is https" do
       let(:settings) {{
         "ssl_enabled" => false,
-        "cloud_id" => "sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA=="
+        "cloud_id" => "sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+        "query" => "*"
       }}
 
       it "should not infer the ssl_enabled value" do
@@ -82,7 +83,8 @@ describe "SSL options" do
 
     context "and cloud_id resolved host is https" do
       let(:settings) {{
-        "cloud_id" => "sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA=="
+        "cloud_id" => "sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+        "query" => "*"
       }}
 
       it "should infer the ssl_enabled value to false" do

--- a/spec/filters/elasticsearch_ssl_spec.rb
+++ b/spec/filters/elasticsearch_ssl_spec.rb
@@ -5,7 +5,7 @@ require "logstash/codecs/base"
 describe "SSL options" do
   let(:es_client_double) { double("Elasticsearch::Client #{self.inspect}") }
   let(:hosts) {["localhost"]}
-  let(:settings) { { "ssl_enabled" => true, "hosts" => hosts } }
+  let(:settings) { { "ssl_enabled" => true, "hosts" => hosts, "query" => "*" } }
 
   subject do
     require "logstash/filters/elasticsearch"


### PR DESCRIPTION
This commit adds checking to ensure either `query` or `query_template` is non empty.
If both are set, the plugin throws error

Fix #170
