### PR TITLE
fix: free resources on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.15.3
+  - Fixes a memory leak that occurs when a pipeline containing this filter terminates, which could become significant if the pipeline is cycled repeatedly.
+
 ## 3.15.2
   - Added checking for `query` and `query_template`. [#171](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/171)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.15.3
-  - Fixes a memory leak that occurs when a pipeline containing this filter terminates, which could become significant if the pipeline is cycled repeatedly.
+  - Fixes a memory leak that occurs when a pipeline containing this filter terminates, which could become significant if the pipeline is cycled repeatedly [#173](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/173)
 
 ## 3.15.2
   - Added checking for `query` and `query_template`. [#171](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/171)

--- a/lib/logstash/filters/elasticsearch/client.rb
+++ b/lib/logstash/filters/elasticsearch/client.rb
@@ -22,6 +22,9 @@ module LogStash
         transport_options[:headers].merge!(setup_api_key(api_key))
         transport_options[:headers].merge!({ 'user-agent' => "#{user_agent}" })
 
+        transport_options[:pool_max] = 1000
+        transport_options[:pool_max_per_route] = 100
+
         logger.warn "Supplied proxy setting (proxy => '') has no effect" if @proxy.eql?('')
         transport_options[:proxy] = proxy.to_s if proxy && !proxy.eql?('')
 

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.15.2'
+  s.version         = '3.15.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -91,21 +91,6 @@ describe LogStash::Filters::Elasticsearch do
       Thread.current[:filter_elasticsearch_client] = nil
     end
 
-    # Since the Elasticsearch Ruby client is not thread safe
-    # and under high load we can get error with the connection pool
-    # we have decided to create a new instance per worker thread which
-    # will be lazy created on the first call to `#filter`
-    #
-    # I am adding a simple test case for future changes
-    it "uses a different connection object per thread wait" do
-      expect(plugin.clients_pool.size).to eq(0)
-
-      Thread.new { plugin.filter(event) }.join
-      Thread.new { plugin.filter(event) }.join
-
-      expect(plugin.clients_pool.size).to eq(2)
-    end
-
     it "should enhance the current event with new data" do
       plugin.filter(event)
       expect(event.get("code")).to eq(404)
@@ -464,6 +449,24 @@ describe LogStash::Filters::Elasticsearch do
 
     after(:each) do
       Thread.current[:filter_elasticsearch_client] = nil
+    end
+
+    it 'uses a threadsafe transport adapter' do
+      client = plugin.send(:get_client).client
+      # we currently rely on the threadsafety guarantees provided by Manticore
+      # this spec is a safeguard to trigger an assessment of thread-safety should
+      # we choose a different transport adapter in the future.
+      expect(extract_transport(client).to_s).to include('Manticore')
+    end
+
+    it 'uses a single shared client across threads' do
+      q = Queue.new
+      10.times.map do
+        Thread.new(plugin) { |instance| q.push instance.send(:get_client) }
+      end.map(&:join)
+
+      first = q.pop
+      expect(q.pop).to be(first) until q.empty?
     end
 
     describe "cloud.id" do


### PR DESCRIPTION
Our transport class Manticore is explicitly threadsafe and by default creates a pool with up to 50 connections; therefore we do not need an individual instance of Manticore per worker thread. Using a shared instance resolves a memory leak that was caused by using a strong reference to the worker threads themselves as a key in the routing to per-thread clients, which prevented those threads from being garbage-collected.

~Additionally, Manticore gives us the opportunity to explicitly close the client to free its resources in advance of garbage collection, so we should propagate `LogStash::Filters::Base#close` to the shared client if it exists.~ _[EDIT: Elasticsearch client doesn't propagate to its transport]_

Supersedes #167 