### PR TITLE
Mark previously deprecated SSL settings as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 4.0.0
-- SSL settings that were marked deprecated in version `3.15.0` are now marked obsolete, and will prevent the plugin from starting.
-- These settings are:
-  - `ca_file`, which should be replaced by `ssl_certificate_authorities`
-  - `keystore`, which should be replaced by `ssl_keystore_path`
-  - `keystore_password`, which should be replaced by `ssl_keystore_password`
-  - `keystore_type`, which should be replaced by `ssl_keystore_password`
-  - `ssl`, which should be replaced by `ssl_enabled`
-  - [#183](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/183)
+  - SSL settings that were marked deprecated in version `3.15.0` are now marked obsolete, and will prevent the plugin from starting.
+  - These settings are:
+    - `ca_file`, which should be replaced by `ssl_certificate_authorities`
+    - `keystore`, which should be replaced by `ssl_keystore_path`
+    - `keystore_password`, which should be replaced by `ssl_keystore_password`
+    - `keystore_type`, which should be replaced by `ssl_keystore_password`
+    -  `ssl`, which should be replaced by `ssl_enabled`
+    - [#183](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/183)
 
 ## 3.16.2
   - Add `x-elastic-product-origin` header to Elasticsearch requests [#185](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+- SSL settings that were marked deprecated in version `3.15.0` are now marked obsolete, and will prevent the plugin from starting.
+- These settings are:
+  - `ca_file`, which should be replaced by `ssl_certificate_authorities`
+  - `keystore`, which should be replaced by `ssl_keystore_path`
+  - `keystore_password`, which should be replaced by `ssl_keystore_password`
+  - `keystore_type`, which should be replaced by `ssl_keystore_password`
+  - `ssl`, which should be replaced by `ssl_enabled`
+  - [#183](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/183)
+
 ## 3.16.2
   - Add `x-elastic-product-origin` header to Elasticsearch requests [#185](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/185)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -110,7 +110,7 @@ Authentication to a secure Elasticsearch cluster is possible using _one_ of the 
 * <<plugins-{type}s-{plugin}-user>> AND <<plugins-{type}s-{plugin}-password>>
 * <<plugins-{type}s-{plugin}-cloud_auth>>
 * <<plugins-{type}s-{plugin}-api_key>>
-* <<plugins-{type}s-{plugin}-keystore>> and/or <<plugins-{type}s-{plugin}-keystore_password>>
+* <<plugins-{type}s-{plugin}-ssl_keystore_path>> and/or <<plugins-{type}s-{plugin}-ssl_keystore_password>>
 
 [id="plugins-{type}s-{plugin}-autz"]
 ==== Authorization

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -121,7 +121,10 @@ The `monitoring` permission at cluster level is necessary to perform periodic co
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Filter Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> and the <<plugins-{type}s-{plugin}-deprecated-options>> described later.
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+
+NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
+<<plugins-{type}s-{plugin}-obsolete-options>> for more details.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -144,7 +147,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-retry_on_failure>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_on_status>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-sort>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of <<string,string>>|No
@@ -519,56 +521,20 @@ Tags the event on failure to look up previous log event information. This can be
 Basic Auth - username
 
 
-[id="plugins-{type}s-{plugin}-deprecated-options"]
-==== Elasticsearch Filter Deprecated Configuration Options
+[id="plugins-{type}s-{plugin}-obsolete-options"]
+==== Elasticsearch Filter Obsolete Configuration Options
 
-This plugin supports the following deprecated configurations.
-
-WARNING: Deprecated options are subject to removal in future releases.
+WARNING: As of version `4.0.0` of this plugin, some configuration options have been replaced.
+The plugin will fail to start if it contains any of these obsolete options.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
-|Setting|Input type|Replaced by
-| <<plugins-{type}s-{plugin}-ca_file>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_keystore_path>>
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+|Setting|Replaced by
+| ca_file |<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| keystore |<<plugins-{type}s-{plugin}-ssl_keystore_path>>
+| keystore_password |<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| ssl |<<plugins-{type}s-{plugin}-ssl_enabled>>
 |=======================================================================
-
-[id="plugins-{type}s-{plugin}-ca_file"]
-===== `ca_file`
-deprecated[3.15.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-
-SSL Certificate Authority file
-
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl`
-deprecated[3.15.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
-
-* Value type is <<boolean,boolean>>
-* Default value is `false`
-
-SSL
-
-[id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore`
-deprecated[3.15.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
-
-* Value type is <<path,path>>
-* There is no default value for this setting.
-
-The keystore used to present a certificate to the server. It can be either .jks or .p12
-
-[id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password`
-deprecated[3.15.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
-
-* Value type is <<password,password>>
-* There is no default value for this setting.
-
-Set the keystore password
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -123,7 +123,7 @@ The `monitoring` permission at cluster level is necessary to perform periodic co
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
-NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
+NOTE: As of version `4.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
 <<plugins-{type}s-{plugin}-obsolete-options>> for more details.
 
 [cols="<,<,<",options="header",]

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.16.2'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', ">= 7.14.9" # LS >= 6.7 and < 7.14 all used version 5.0.5
   s.add_runtime_dependency 'manticore', ">= 0.7.1"
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~> 1.0'
-  s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
   s.add_development_dependency 'cabin', ['~> 0.6']
   s.add_development_dependency 'webrick'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/filters/elasticsearch_ssl_spec.rb
+++ b/spec/filters/elasticsearch_ssl_spec.rb
@@ -24,6 +24,23 @@ describe "SSL options" do
     subject.close
   end
 
+  describe "obsolete settings" do
+    [{:name => 'ca_file', :canonical_name => 'ssl_certificate_authorities'},
+     {:name => "keystore", :canonical_name => 'ssl_keystore_path'},
+     {:name => "keystore_password", :canonical_name => "ssl_keystore_password"},
+     {:name => "ssl", :canonical_name => "ssl_enabled"}
+    ].each do |config_settings|
+      context "with option #{config_settings[:name]}" do
+        let(:obsolete_config) { settings.merge(config_settings[:name] => 'test_value') }
+        it "emits an error about the setting `#{config_settings[:name]}` now being obsolete and provides guidance to use `#{config_settings[:canonical_name]}`" do
+          error_text = /The setting `#{config_settings[:name]}` in plugin `elasticsearch` is obsolete and is no longer available. Set '#{config_settings[:canonical_name]}' instead/i
+          expect { LogStash::Filters::Elasticsearch.new(obsolete_config) }.to raise_error LogStash::ConfigurationError, error_text
+        end
+
+      end
+    end
+  end
+
   context "when ssl_enabled is" do
     context "true and there is no https hosts" do
       let(:hosts) { %w[http://es01 http://es01] }


### PR DESCRIPTION
- SSL settings that were marked deprecated in version `3.15.0` are now marked obsolete, and will prevent the plugin from starting.
- These settings are:
  - `ca_file`, which should be replaced by `ssl_certificate_authorities`
  - `keystore`, which should be replaced by `ssl_keystore_path`
  - `keystore_password`, which should be replaced by `ssl_keystore_password`
  - `keystore_type`, which should be replaced by `ssl_keystore_password`
  - `ssl`, which should be replaced by `ssl_enabled`

Relates: https://github.com/logstash-plugins/logstash-filter-elasticsearch/issues/179