### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -83,7 +83,7 @@ template.json:
 [source,json]
 --------------------------------------------------
 {
-  "size": 1,
+  "result_size": 1,
   "sort" : [ { "@timestamp" : "desc" } ],
   "query": {
     "query_string": {


### PR DESCRIPTION
Issue: The size parameter in template.json as well as in the sample example codes should be updated to result_size. Using size in Elasticsearch filter plugin v3.16.1 in logstash causes a configuration error stating that the size field is unrecognized.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
