### PR TITLE
Set x-elastic-product-origin header for ES requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.16.2
+  - Add `x-elastic-product-origin` header to Elasticsearch requests [#185](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/185)
+
 ## 3.16.1
   - Version bump to pick up doc fix in [#172](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/172)
 

--- a/lib/logstash/filters/elasticsearch/client.rb
+++ b/lib/logstash/filters/elasticsearch/client.rb
@@ -12,6 +12,7 @@ module LogStash
 
       BUILD_FLAVOR_SERVERLESS = 'serverless'.freeze
       DEFAULT_EAV_HEADER = { "Elastic-Api-Version" => "2023-10-31" }.freeze
+      INTERNAL_ORIGIN_HEADER = { 'x-elastic-product-origin' => 'logstash-filter-elasticsearch'}.freeze
 
       def initialize(logger, hosts, options = {})
         user = options.fetch(:user, nil)
@@ -25,6 +26,7 @@ module LogStash
         transport_options[:headers].merge!(setup_basic_auth(user, password))
         transport_options[:headers].merge!(setup_api_key(api_key))
         transport_options[:headers].merge!({ 'user-agent' => "#{user_agent}" })
+        transport_options[:headers].merge!(INTERNAL_ORIGIN_HEADER)
 
         transport_options[:pool_max] = 1000
         transport_options[:pool_max_per_route] = 100

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '3.16.1'
+  s.version         = '3.16.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -644,7 +644,7 @@ describe LogStash::Filters::Elasticsearch do
     end
   end
 
-  describe "Elastic Api Header" do
+  describe "Elastic Api and Product Origin Headers" do
     let(:config) { {"query" => "*"} }
     let(:plugin) { described_class.new(config) }
     let(:headers) {{'x-elastic-product' => 'Elasticsearch'}}
@@ -666,6 +666,8 @@ describe LogStash::Filters::Elasticsearch do
         plugin.register
         client = plugin.send(:get_client).client
         expect( extract_transport(client).options[:transport_options][:headers] ).to match hash_including("Elastic-Api-Version" => "2023-10-31")
+        expect( extract_transport(client).options[:transport_options][:headers] )
+          .to match hash_including("x-elastic-product-origin" => "logstash-filter-elasticsearch")
       end
     end
 
@@ -676,10 +678,12 @@ describe LogStash::Filters::Elasticsearch do
         expect_any_instance_of(Elasticsearch::Client).to receive(:perform_request).with(any_args).and_return(mock_resp)
       end
 
-      it 'does not propagate header to es client' do
+      it 'does not propagate Elastic-Api-Version header to es client' do
         plugin.register
         client = plugin.send(:get_client).client
         expect( extract_transport(client).options[:transport_options][:headers] ).to match hash_not_including("Elastic-Api-Version" => "2023-10-31")
+        expect( extract_transport(client).options[:transport_options][:headers] )
+          .to match hash_including("x-elastic-product-origin" => "logstash-filter-elasticsearch")
       end
     end
 


### PR DESCRIPTION
This commit updates the `Elasticsearch::Client` used to make requests to ES to
send along a header identifying the request as originating from an internal
component.

Closes https://github.com/logstash-plugins/logstash-filter-elasticsearch/issues/180