### PR TITLE
ES|QL support

### DIFF
--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -8,6 +8,10 @@ require "monitor"
 require_relative "elasticsearch/client"
 
 class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
+
+  require 'logstash/filters/elasticsearch/dsl_executor'
+  require 'logstash/filters/elasticsearch/esql_executor'
+
   config_name "elasticsearch"
 
   # List of elasticsearch hosts to use for querying.
@@ -17,8 +21,13 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # Field substitution (e.g. `index-name-%{date_field}`) is available
   config :index, :validate => :string, :default => ""
 
-  # Elasticsearch query string. Read the Elasticsearch query string documentation.
-  # for more info at: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
+  # Query mode to define what query style/syntax is used with @query param.
+  config :query_mode, :validate => %w[esql dsl], :default => "dsl"
+
+  # Elasticsearch query string. This can be in DSL or ES|QL query shape.
+  # Read the Elasticsearch query string documentation.
+  #   DSL: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html#query-string-syntax
+  #   ES|QL: https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html
   config :query, :validate => :string
 
   # File path to elasticsearch query in DSL format. Read the Elasticsearch query documentation
@@ -124,6 +133,11 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # What status codes to retry on?
   config :retry_on_status, :validate => :number, :list => true, :default => [500, 502, 503, 504]
 
+  # params to send to ES|QL query, naming params preferred
+  # example,
+  #   if query is "FROM my-index | WHERE some_type = ?type"
+  #   esql_params => [{"type": "@type_field"}]
+  config :esql_params, :validate => :array, :default => []
 
   config :ssl, :obsolete => "Set 'ssl_enabled' instead."
   config :ca_file, :obsolete => "Set 'ssl_certificate_authorities' instead."
@@ -176,70 +190,22 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     if get_client.es_transport_client_type == "elasticsearch_transport"
       require_relative "elasticsearch/patches/_elasticsearch_transport_http_manticore"
     end
+
+    if @query_mode == "esql"
+      @esql_executor ||= LogStash::Filters::Elasticsearch::EsqlExecutor.new(self, @logger)
+    else
+      @esql_executor ||= LogStash::Filters::Elasticsearch::DslExecutor.new(self, @logger)
+    end
   end # def register
 
   def filter(event)
-    matched = false
-    begin
-      params = { :index => event.sprintf(@index) }
-
-      if @query_dsl
-        query = LogStash::Json.load(event.sprintf(@query_dsl))
-        params[:body] = query
-      else
-        query = event.sprintf(@query)
-        params[:q] = query
-        params[:size] = result_size
-        params[:sort] =  @sort if @enable_sort
-      end
-
-      @logger.debug("Querying elasticsearch for lookup", :params => params)
-
-      results = get_client.search(params)
-      raise "Elasticsearch query error: #{results["_shards"]["failures"]}" if results["_shards"].include? "failures"
-
-      event.set("[@metadata][total_hits]", extract_total_from_hits(results['hits']))
-
-      resultsHits = results["hits"]["hits"]
-      if !resultsHits.nil? && !resultsHits.empty?
-        matched = true
-        @fields.each do |old_key, new_key|
-          old_key_path = extract_path(old_key)
-          set = resultsHits.map do |doc|
-            extract_value(doc["_source"], old_key_path)
-          end
-          event.set(new_key, set.count > 1 ? set : set.first)
-        end
-        @docinfo_fields.each do |old_key, new_key|
-          old_key_path = extract_path(old_key)
-          set = resultsHits.map do |doc|
-            extract_value(doc, old_key_path)
-          end
-          event.set(new_key, set.count > 1 ? set : set.first)
-        end
-      end
-
-      resultsAggs = results["aggregations"]
-      if !resultsAggs.nil? && !resultsAggs.empty?
-        matched = true
-        @aggregation_fields.each do |agg_name, ls_field|
-          event.set(ls_field, resultsAggs[agg_name])
-        end
-      end
-
-    rescue => e
-      if @logger.trace?
-        @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :query => query, :event => event.to_hash, :error => e.message, :backtrace => e.backtrace)
-      elsif @logger.debug?
-        @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :error => e.message, :backtrace => e.backtrace)
-      else
-        @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :error => e.message)
-      end
-      @tag_on_failure.each{|tag| event.tag(tag)}
-    else
-      filter_matched(event) if matched
-    end
+    @esql_executor.process(get_client, event)
   end # def filter
+
+  def decorate(event)
+    # Elasticsearch class has an access for `filter_matched`
+    filter_matched(event)
+  end
 
   # public only to be reuse in testing
   def prepare_user_agent
@@ -350,39 +316,6 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
     @shared_client || synchronize do
       @shared_client ||= new_client
     end
-  end
-
-  # get an array of path elements from a path reference
-  def extract_path(path_reference)
-    return [path_reference] unless path_reference.start_with?('[') && path_reference.end_with?(']')
-
-    path_reference[1...-1].split('][')
-  end
-
-  # given a Hash and an array of path fragments, returns the value at the path
-  # @param source [Hash{String=>Object}]
-  # @param path [Array{String}]
-  # @return [Object]
-  def extract_value(source, path)
-    path.reduce(source) do |memo, old_key_fragment|
-      break unless memo.include?(old_key_fragment)
-      memo[old_key_fragment]
-    end
-  end
-
-  # Given a "hits" object from an Elasticsearch response, return the total number of hits in
-  # the result set.
-  # @param hits [Hash{String=>Object}]
-  # @return [Integer]
-  def extract_total_from_hits(hits)
-    total = hits['total']
-
-    # Elasticsearch 7.x produces an object containing `value` and `relation` in order
-    # to enable unambiguous reporting when the total is only a lower bound; if we get
-    # an object back, return its `value`.
-    return total['value'] if total.kind_of?(Hash)
-
-    total
   end
 
   def hosts_default?(hosts)

--- a/lib/logstash/filters/elasticsearch/client.rb
+++ b/lib/logstash/filters/elasticsearch/client.rb
@@ -55,8 +55,8 @@ module LogStash
         @client = ::Elasticsearch::Client.new(client_options)
       end
 
-      def search(params={})
-        @client.search(params)
+      def search(params={}, query_type = 'dsl')
+        query_type == 'esql' ? @client.esql.query(params) : @client.search(params)
       end
 
       def info

--- a/lib/logstash/filters/elasticsearch/dsl_executor.rb
+++ b/lib/logstash/filters/elasticsearch/dsl_executor.rb
@@ -1,0 +1,121 @@
+# encoding: utf-8
+
+module LogStash
+  module Filters
+    class Elasticsearch
+      class DslExecutor
+        def initialize(plugin, logger)
+          @plugin = plugin
+          @index = plugin.params["index"]
+          @query = plugin.params["query"]
+          @fields = plugin.params["fields"]
+          @result_size = plugin.params["result_size"]
+          @docinfo_fields = plugin.params["docinfo_fields"]
+          @tag_on_failure = plugin.params["tag_on_failure"]
+          @query_dsl = plugin.params["query_dsl"]
+          @enable_sort = plugin.params["enable_sort"]
+          @sort = plugin.params["sort"]
+          @logger = logger
+        end
+
+        def process(client, event)
+          matched = false
+          begin
+            params = { :index => event.sprintf(@index) }
+
+            if @query_dsl
+              query = LogStash::Json.load(event.sprintf(@query_dsl))
+              params[:body] = query
+            else
+              query = event.sprintf(@query)
+              params[:q] = query
+              params[:size] = @result_size
+              params[:sort] = @sort if @enable_sort
+            end
+
+            @logger.debug("Querying elasticsearch for lookup", :params => params)
+
+            results = client.search(params)
+            raise "Elasticsearch query error: #{results["_shards"]["failures"]}" if results["_shards"].include? "failures"
+
+            event.set("[@metadata][total_hits]", extract_total_from_hits(results['hits']))
+
+            result_hits = results["hits"]["hits"]
+            if !result_hits.nil? && !result_hits.empty?
+              matched = true
+              @fields.each do |old_key, new_key|
+                old_key_path = extract_path(old_key)
+                set = result_hits.map do |doc|
+                  extract_value(doc["_source"], old_key_path)
+                end
+                event.set(new_key, set.count > 1 ? set : set.first)
+              end
+              @docinfo_fields.each do |old_key, new_key|
+                old_key_path = extract_path(old_key)
+                set = result_hits.map do |doc|
+                  extract_value(doc, old_key_path)
+                end
+                event.set(new_key, set.count > 1 ? set : set.first)
+              end
+            end
+
+            result_aggregations = results["aggregations"]
+            if !result_aggregations.nil? && !result_aggregations.empty?
+              matched = true
+              @aggregation_fields.each do |agg_name, ls_field|
+                event.set(ls_field, result_aggregations[agg_name])
+              end
+            end
+
+          rescue => e
+            if @logger.trace?
+              @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :query => @query, :event => event.to_hash, :error => e.message, :backtrace => e.backtrace)
+            elsif @logger.debug?
+              @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :error => e.message, :backtrace => e.backtrace)
+            else
+              @logger.warn("Failed to query elasticsearch for previous event", :index => @index, :error => e.message)
+            end
+            @tag_on_failure.each { |tag| event.tag(tag) }
+          else
+            @plugin.decorate(event) if matched
+          end
+        end
+
+        private
+
+        # Given a "hits" object from an Elasticsearch response, return the total number of hits in
+        # the result set.
+        # @param hits [Hash{String=>Object}]
+        # @return [Integer]
+        def extract_total_from_hits(hits)
+          total = hits['total']
+
+          # Elasticsearch 7.x produces an object containing `value` and `relation` in order
+          # to enable unambiguous reporting when the total is only a lower bound; if we get
+          # an object back, return its `value`.
+          return total['value'] if total.kind_of?(Hash)
+          total
+        end
+
+        # get an array of path elements from a path reference
+        def extract_path(path_reference)
+          return [path_reference] unless path_reference.start_with?('[') && path_reference.end_with?(']')
+
+          path_reference[1...-1].split('][')
+        end
+
+        # given a Hash and an array of path fragments, returns the value at the path
+        # @param source [Hash{String=>Object}]
+        # @param path [Array{String}]
+        # @return [Object]
+        def extract_value(source, path)
+          path.reduce(source) do |memo, old_key_fragment|
+            break unless memo.include?(old_key_fragment)
+            memo[old_key_fragment]
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/logstash/filters/elasticsearch/esql_executor.rb
+++ b/lib/logstash/filters/elasticsearch/esql_executor.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+module LogStash
+  module Filters
+    class Elasticsearch
+      class EsqlExecutor
+
+        def initialize(plugin, logger)
+          @plugin = plugin
+          @esql_params = plugin.params["esql_params"]
+          @query = plugin.params["query"]
+          @fields = plugin.params["fields"]
+          @tag_on_failure = plugin.params["tag_on_failure"]
+          @logger = logger
+        end
+
+        def process(client, event)
+          resolved_params = @esql_params&.any? ? resolve_parameters(event) : []
+          response = execute_query(client, resolved_params)
+          inform_warning(response)
+          process_response(event, response)
+          @plugin.decorate(event)
+        rescue => e
+          @logger.error("Failed to process ES|QL filter", exception: e)
+          @tag_on_failure.each { |tag| event.tag(tag) }
+        end
+
+        private
+
+        def resolve_parameters(event)
+          @esql_params.map do |entry|
+            entry.each_with_object({}) do |(key, value), new_entry|
+              begin
+                new_entry[key] = event.sprintf(value)
+              rescue => e
+                @logger.error("Failed to resolve parameter", key: key, value: value, error: e.message)
+                raise
+              end
+            end
+          end
+        end
+
+        def execute_query(client, params)
+          @logger.debug("Executing ES|QL query", query: @query, params: params)
+          client.search({ body: { query: @query, params: params }, format: 'json' }, 'esql')
+        end
+
+        def process_response(event, response)
+          return unless response['values'] && response['columns']
+
+          event.set("[@metadata][total_hits]", response['values'].size)
+          add_requested_fields(event, response)
+        end
+
+        def inform_warning(response)
+          return unless (warning = response&.headers&.dig('warning'))
+          @logger.warn("ES|QL query execution warning: ", { message: warning })
+        end
+
+        def handle_errors(response)
+          return unless response&.headers&.dig("warning")
+          @logger.warn("ES|QL query execution warning: ", message: response.headers['warning'])
+        end
+
+        def add_requested_fields(event, response)
+          @fields.each do |old_key, new_key|
+            column_index = response['columns'].find_index { |col| col['name'] == old_key }
+            next unless column_index
+
+            values = response['values'].map { |entry| entry[column_index] }
+            event.set(new_key, values.one? ? values.first : values) if values&.size > 0
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Design note: https://docs.google.com/document/d/1EZMe0OU7Ceyg9aUawARh2N2iFq196mVTWxut2abGIEY
- Needs team's input to make decision on params, namings and etc...

PR changes: 
- ESQL and DSL executors are introduced.
- `query` param can accept ES|QL query shape now.
- `esql_params` is introduced for initial step but needs team's feedback.
- DSL logics moved into DSL executors.

Sample minimal config:
```
elasticsearch {
      cloud_id => "my-cloud-id"
      api_key => "api:key"
      query_mode => "esql"
      query => "FROM significant_month | WHERE type == ?type"
      esql_params => [{"type" => "%{[type]}"}]
      fields => { "@timestamp" => "timestamp_new" }
   }
```

### Author's checklist
- [ ] Add validation logic similar to es-input
- [ ] Unit tests
- [ ] Integration tests
- [ ] Documentation
- [ ] Version bump (plan for both 8.x and 9.x)


### Log
```
[2025-04-17T16:47:56,901][WARN ][logstash.filters.elasticsearch][main][0d04e11c949906b1abe5db3c4991ecafac9bc4925a31d477fe5427ec1369304a] ES|QL query execution warning:  {:message=>"299 Elasticsearch-8.17.0-2b6a7fed44faa321997703718f07ee0420804b41 \"No limit defined, adding default limit of [1000]\""}
{
               "dmin" => 2.187,
          "magSource" => "us",
         "depthError" => 1.697,
           "latitude" => -6.3171,
               "type" => "earthquake",
            "magType" => "mww",
                "nst" => 324,
                "mag" => 6.9,
           "magError" => 0.028,
    "horizontalError" => 6.62,
                "gap" => 11,
      "timestamp_new" => [
        [ 0] "2025-04-04T20:04:38.266Z",
        [ 1] "2025-04-03T14:09:29.757Z",
        [ 2] "2025-04-02T00:29:22.130Z",
        [ 3] "2025-03-30T12:18:47.830Z",
        [ 4] "2025-03-28T17:17:27.821Z",
        [ 5] "2025-03-28T06:32:04.726Z",
        [ 6] "2025-03-28T06:20:52.684Z",
        [ 7] "2025-03-25T01:43:11.796Z",
        [ 8] "2025-03-21T14:50:51.098Z",
        [ 9] "2025-03-18T02:46:33.330Z",
        [10] "2025-03-17T03:17:21.650Z",
        [11] "2025-03-10T02:33:14.609Z"
    ],
           "@version" => "1",
                "rms" => 0.78,
              "place" => "181 km ESE of Kimbe, Papua New Guinea",
                 "id" => "us6000q41n",
                "net" => "us",
          "longitude" => 151.5922,
          "@metadata" => {
        "total_hits" => 12
    },
     "locationSource" => "us",
         "@timestamp" => 2025-04-04T20:04:38.266Z,
              "depth" => 10.0,
           "location" => "POINT (151.5922 -6.3171)",
             "magNst" => 121,
               "time" => "2025-04-04T20:04:38.266Z",
            "updated" => "2025-04-08T19:27:52.892Z",
             "status" => "reviewed"
}

```