### PR TITLE
Add a target field support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.0
+  - Add `target` configuration option to store the result into it [#196](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/196)
+
 ## 4.1.1
   - Add elastic-transport client support used in elasticsearch-ruby 8.x [#191](https://github.com/logstash-plugins/logstash-filter-elasticsearch/pull/191)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -530,9 +530,10 @@ Tags the event on failure to look up previous log event information. This can be
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-Define the target field for placing the result data. If this setting is
-omitted, the result data will be stored at the root (top level) of the event.
-If `@fields` are set, the result data will be combined.
+Define the target field for placing the result data.
+If this setting is omitted, the target will be the root (top level) of the event.
+
+The destination fields specified in <<plugins-{type}s-{plugin}-fields>>, <<plugins-{type}s-{plugin}-aggregation_fields>>, and <<plugins-{type}s-{plugin}-docinfo_fields>> are relative to this target.
 
 For example, if you want the data to be put in the `operation` field:
 [source,ruby]
@@ -558,7 +559,7 @@ if [type] == "end" {
       }
     }
 
-NOTE: if the `target` field already exists in the event, it will be overwritten.
+NOTE: when writing to a field that already exists on the event, the previous value will be overwritten.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -162,6 +162,7 @@ NOTE: As of version `4.0.0` of this plugin, a number of previously deprecated se
 | <<plugins-{type}s-{plugin}-ssl_truststore_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
 
@@ -522,6 +523,42 @@ WARNING: Setting certificate verification to `none` disables many security benef
   * Default value is `["_elasticsearch_lookup_failure"]`
 
 Tags the event on failure to look up previous log event information. This can be used in later analysis.
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+Define the target field for placing the result data. If this setting is
+omitted, the result data will be stored at the root (top level) of the event.
+If `@fields` are set, the result data will be combined.
+
+For example, if you want the data to be put in the `operation` field:
+[source,ruby]
+if [type] == "end" {
+    filter {
+      query => "type:start AND transaction:%{[transactionId]}"
+      elasticsearch {
+        target => "transaction"
+        fields => {
+          "@timestamp" => "started"
+          "transaction_id" => "id"
+        }
+      }
+    }
+}
+
+`fields` fields will be expanded into a data structure in the `target` field, overall shape looks like this:
+[source,ruby]
+    {
+      "transaction" => {
+        "started" => "2025-04-29T12:01:46.263Z"
+        "id" => "1234567890"
+      }
+    }
+
+NOTE: if the `target` field already exists in the event, it will be overwritten.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -176,8 +176,11 @@ filter plugins.
 
   * Value type is <<hash,hash>>
   * Default value is `{}`
+  * Format: `"aggregation_name" => "[path][on][event]"`:
+  ** `aggregation_name`: aggregation name in result from {es}
+  ** `[path][on][event]`: path for where to place the value on the current event, using field-reference notation
 
-Hash of aggregation names to copy from elasticsearch response into Logstash event fields
+A mapping of aggregations to copy into the <<plugins-{type}s-{plugin}-target>> of the current event.
 
 Example:
 [source,ruby]
@@ -247,8 +250,11 @@ These custom headers will override any headers previously set by the plugin such
 
   * Value type is <<hash,hash>>
   * Default value is `{}`
+  * Format: `"path.in.source" => "[path][on][event]"`:
+  ** `path.in.source`: field path in document source of result from {es}, using dot-notation
+  ** `[path][on][event]`: path for where to place the value on the current event, using field-reference notation
 
-Hash of docinfo fields to copy from old event (found via elasticsearch) into new event
+A mapping of docinfo (`_source`) fields to copy into the <<plugins-{type}s-{plugin}-target>> of the current event.
 
 Example:
 [source,ruby]
@@ -274,9 +280,11 @@ Whether results should be sorted or not
 
   * Value type is <<array,array>>
   * Default value is `{}`
+  * Format: `"path.in.result" => "[path][on][event]"`:
+  ** `path.in.result`: field path in indexed result from {es}, using dot-notation
+  ** `[path][on][event]`: path for where to place the value on the current event, using field-reference notation
 
-An array of fields to copy from the old event (found via elasticsearch) into the
-new event, currently being processed.
+A mapping of indexed fields to copy into the <<plugins-{type}s-{plugin}-target>> of the current event.
 
 In the following example, the values of `@timestamp` and `event_id` on the event
 found via elasticsearch are copied to the current event's

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -218,7 +218,8 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
           extracted_hit_values = resultsHits.map do |doc|
             extract_value(doc["_source"], old_key_path)
           end
-          set_to_event_target(event, new_key, extracted_hit_values)
+          value_to_set = extracted_hit_values.count > 1 ? extracted_hit_values : extracted_hit_values.first
+          set_to_event_target(event, new_key, value_to_set)
         end
         @docinfo_fields.each do |old_key, new_key|
           old_key_path = extract_path(old_key)
@@ -270,10 +271,9 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
   # if not defined, directly sets to the top-level event field
   # @param event [LogStash::Event]
   # @param new_key [String] name of the field to set
-  # @param values [Array] values to set
+  # @param value_to_set [Array] values to set
   # @return [void]
-  def set_to_event_target(event, new_key, values)
-    value_to_set = values.count > 1 ? values : values.first
+  def set_to_event_target(event, new_key, value_to_set)
     key_to_set = target ? "[#{target}][#{new_key}]" : new_key
 
     event.set(key_to_set, value_to_set)

--- a/lib/logstash/filters/elasticsearch.rb
+++ b/lib/logstash/filters/elasticsearch.rb
@@ -223,10 +223,11 @@ class LogStash::Filters::Elasticsearch < LogStash::Filters::Base
         end
         @docinfo_fields.each do |old_key, new_key|
           old_key_path = extract_path(old_key)
-          set = resultsHits.map do |doc|
+          extracted_docs_info = resultsHits.map do |doc|
             extract_value(doc, old_key_path)
           end
-          event.set(new_key, set.count > 1 ? set : set.first)
+          value_to_set = extracted_docs_info.count > 1 ? extracted_docs_info : extracted_docs_info.first
+          set_to_event_target(event, new_key, value_to_set)
         end
       end
 

--- a/logstash-filter-elasticsearch.gemspec
+++ b/logstash-filter-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-elasticsearch'
-  s.version         = '4.1.1'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Copies fields from previous log events in Elasticsearch to current events "
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'elasticsearch', ">= 7.14.9", '< 9'
   s.add_runtime_dependency 'manticore', ">= 0.7.1"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_development_dependency 'cabin', ['~> 0.6']
   s.add_development_dependency 'webrick'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -864,7 +864,7 @@ describe LogStash::Filters::Elasticsearch do
     end
   end
 
-  describe "setting target" do
+  describe "#set_to_event_target" do
 
     context "when `@target` is nil, default behavior" do
       let(:config) {{ }}

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -864,6 +864,33 @@ describe LogStash::Filters::Elasticsearch do
     end
   end
 
+  context "setting target" do
+
+    describe "when `@target` is nil, default behavior" do
+      let(:config) {{ }}
+
+      it "sets the value directly to the top-level event field" do
+        plugin.send(:set_to_event_target, event, "new_field", %w[value1 value2])
+        expect(event.get("new_field")).to eq(%w[value1 value2])
+      end
+    end
+
+    describe "when @target is defined" do
+      let(:config) {{ "target" => "nested" }}
+
+      it "creates a nested structure under the target field" do
+        plugin.send(:set_to_event_target, event, "new_field", %w[value1 value2])
+        expect(event.get("nested")).to eq({ "new_field" => %w[value1 value2] })
+      end
+
+      it "overwrites existing target field with new data" do
+        event.set("nested", { "existing_field" => "existing_value", "new_field" => "value0" })
+        plugin.send(:set_to_event_target, event, "new_field", ["value1"])
+        expect(event.get("nested")).to eq({ "existing_field" => "existing_value", "new_field" => "value1" })
+      end
+    end
+  end
+
   def extract_transport(client)
     # on 7x: client.transport.transport
     # on >=8.x: client.transport

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -864,9 +864,9 @@ describe LogStash::Filters::Elasticsearch do
     end
   end
 
-  context "setting target" do
+  describe "setting target" do
 
-    describe "when `@target` is nil, default behavior" do
+    context "when `@target` is nil, default behavior" do
       let(:config) {{ }}
 
       it "sets the value directly to the top-level event field" do
@@ -875,7 +875,7 @@ describe LogStash::Filters::Elasticsearch do
       end
     end
 
-    describe "when @target is defined" do
+    context "when @target is defined" do
       let(:config) {{ "target" => "nested" }}
 
       it "creates a nested structure under the target field" do

--- a/spec/filters/elasticsearch_spec.rb
+++ b/spec/filters/elasticsearch_spec.rb
@@ -886,7 +886,7 @@ describe LogStash::Filters::Elasticsearch do
       it "overwrites existing target field with new data" do
         event.set("nested", { "existing_field" => "existing_value", "new_field" => "value0" })
         plugin.send(:set_to_event_target, event, "new_field", ["value1"])
-        expect(event.get("nested")).to eq({ "existing_field" => "existing_value", "new_field" => "value1" })
+        expect(event.get("nested")).to eq({ "existing_field" => "existing_value", "new_field" => ["value1"] })
       end
     end
   end

--- a/spec/filters/integration/elasticsearch_spec.rb
+++ b/spec/filters/integration/elasticsearch_spec.rb
@@ -84,7 +84,9 @@ describe LogStash::Filters::Elasticsearch, :integration => true do
     end
 
     it "fails to register plugin" do
-      expect { plugin.register }.to raise_error Elasticsearch::Transport::Transport::Errors::Unauthorized
+      expect { plugin.register }.to raise_error elastic_ruby_v8_client_available? ?
+                                                  Elastic::Transport::Transport::Errors::Unauthorized :
+                                                  Elasticsearch::Transport::Transport::Errors::Unauthorized
     end
 
   end if ELASTIC_SECURITY_ENABLED
@@ -150,5 +152,10 @@ describe LogStash::Filters::Elasticsearch, :integration => true do
       end
     end
   end
-
+  def elastic_ruby_v8_client_available?
+    Elasticsearch::Transport
+    false
+  rescue NameError # NameError: uninitialized constant Elasticsearch::Transport if Elastic Ruby client is not available
+    true
+  end
 end


### PR DESCRIPTION
Introduces a target field as a field reference (mixin validated) where if set result is placed into the target.


### Test logs
- when using target and DSL query
```
// config
query => "magType:%{[target-input-field][magType]}"
fields => { "depthError" => "[target-input-field][depthErrorValue]" }
target => "my-ls-filter-target"

// result
{
    "my-ls-filter-target" => {
        "target-input-field" => {
            "depthErrorValue" => 1.697
        }
    },
             "@timestamp" => 2025-05-01T19:55:25.268932Z,
     "target-input-field" => {
                   "dmin" => 2.187,
              "magSource" => "us",
             "depthError" => 1.697,
               "latitude" => -6.3171,
         "locationSource" => "us",
                   "type" => "earthquake",
                "magType" => "mww",
                    "nst" => 324,
                    "mag" => 6.9,
                  "depth" => 10.0,
             "@timestamp" => 2025-04-04T20:04:38.266Z,
               "magError" => 0.028,
        "horizontalError" => 6.62,
                    "gap" => 11,
                    "rms" => 0.78,
               "location" => "POINT (151.5922 -6.3171)",
                   "time" => 2025-04-04T20:04:38.266Z,
                     "id" => "us6000q41n",
                  "place" => "181 km ESE of Kimbe, Papua New Guinea",
                 "magNst" => 121,
                    "net" => "us",
                "updated" => 2025-04-08T19:27:52.892Z,
                 "status" => "reviewed",
              "longitude" => 151.5922
    },
              "@metadata" => {
        "total_hits" => 10
    },
               "@version" => "1"
}

``` 
- when using target and aggregation query
```
// config
target => "my-ls-filter-target"
aggregation_fields => { "my-aggr" => "my_ls_aggr_field" }
// result
{
    "my-ls-filter-target" => {
        "my_ls_aggr_field" => {
            "doc_count_error_upper_bound" => 0,
                    "sum_other_doc_count" => 0,
                                "buckets" => [
                [0] {
                    "doc_count" => 10,
                          "key" => "mww"
                },
                [1] {
                    "doc_count" => 2,
                          "key" => "mw"
                }
            ]
        }
    },
             "@timestamp" => 2025-05-01T19:53:19.292876Z,
     "target-input-field" => {
                   "dmin" => 2.187,
              "magSource" => "us",
             "depthError" => 1.697,
               "latitude" => -6.3171,
         "locationSource" => "us",
                   "type" => "earthquake",
                "magType" => "mww",
                    "nst" => 324,
                    "mag" => 6.9,
             "@timestamp" => 2025-04-04T20:04:38.266Z,
                  "depth" => 10.0,
               "magError" => 0.028,
        "horizontalError" => 6.62,
                    "gap" => 11,
                    "rms" => 0.78,
               "location" => "POINT (151.5922 -6.3171)",
                     "id" => "us6000q41n",
                   "time" => 2025-04-04T20:04:38.266Z,
                 "magNst" => 121,
                  "place" => "181 km ESE of Kimbe, Papua New Guinea",
                    "net" => "us",
                "updated" => 2025-04-08T19:27:52.892Z,
                 "status" => "reviewed",
              "longitude" => 151.5922
    },
              "@metadata" => {
        "total_hits" => 12
    },
               "@version" => "1"
}

```