### PR TITLE
Removes `secure_integration` tag from CI script since it is internally handled.

### DIFF
--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -24,7 +24,7 @@ wait_for_es() {
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
-  bundle exec rspec --format=documentation spec/filters --tag ~integration --tag ~secure_integration
+  bundle exec rspec --format=documentation spec/filters --tag ~integration
 else
   # SECURE_INTEGRATION is handled inside the specs
   extra_tag_args="--tag integration"


### PR DESCRIPTION
### Description
It seems historically `elasticsearch_spec.rb` integration test never run with `SECURE_INTEGRATION` option.
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/01be976d-6458-4807-b31f-172ec00aa9d3" />
Example runs:
- https://app.travis-ci.com/github/logstash-plugins/logstash-filter-elasticsearch/jobs/629834680
- https://app.travis-ci.com/github/logstash-plugins/logstash-filter-elasticsearch/jobs/631436310

As `elasticsearch_spec.rb` internally applies options based on `SECURE_INTEGRATION` env var, it is not required to add an extra tag when running rspec.


After this PR, we can see 6 examples are running...
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/d82a011e-3ba4-4018-aa47-20f542bd2b0a" />
