### PR TITLE
Remove 8.previous test definitions from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ import:
 jobs:
   include:
     - stage: "Integration Tests"
-      env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.previous
-    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
+      env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true SNAPSHOT=false LOG_LEVEL=info ELASTIC_STACK_VERSION=9.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=9.next
     - env: INTEGRATION=true SNAPSHOT=true ELASTIC_PASSWORD=password ELASTIC_SECURITY_ENABLED=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current


### PR DESCRIPTION
The 8.previous stack version alias is being retired. Remove the corresponding integration test entries.
